### PR TITLE
While playing I noticed that pf2e-reaction sometimes didn't guard aga…

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -3,9 +3,9 @@ async function ringBell(message) {
         if (hasReaction(message?.target?.token?.combatant)) {
             const ring_bell = actorAction(message?.target?.actor, "ring-bell");
             if (ring_bell
-                    && getEnemyDistance(message.token, message.target.token)<=30
+                    && getEnemyDistance(message.token, message.target?.token)<=30
                     && hasExploitVulnerabilityEffect(message.actor, message?.target?.actor)) {
-                    await postInChatTemplate(_uuid(ring_bell), message.target.token.combatant);
+                    await postInChatTemplate(_uuid(ring_bell), message.target?.token.combatant);
             }
         }
         if (isTargetCharacter(message)) {
@@ -90,9 +90,9 @@ async function amuletsAbeyance(message) {
         //ally damaged
         if (message?.target) {
             (isTargetCharacter(message) ? characterWithReaction() : npcWithReaction())
-            .filter(a=>a?.actor?.id != message?.target?.actor._id)
+            .filter(a=>a?.actor?.id !== message?.target?.actor._id)
             .forEach(cc => {
-                if (getEnemyDistance(message.target.token, cc.token) <= 15 && hasExploitVulnerabilityEffect(message.actor, cc.actor)) {
+                if (getEnemyDistance(message.target?.token, cc.token) <= 15 && hasExploitVulnerabilityEffect(message.actor, cc.actor)) {
                     const aab = actorAction(cc.actor, "amulets-abeyance");
                     if (aab) {
                         postTargetInChatTemplate(_uuid(aab), cc);
@@ -108,9 +108,9 @@ async function retributiveStrike(message) {
         //ally damaged
         if (message?.target) {
             (isTargetCharacter(message) ? characterWithReaction() : npcWithReaction())
-            .filter(a=>a?.actor?.id != message?.target?.actor._id)
+            .filter(a=>a?.actor?.id !== message?.target?.actor._id)
             .forEach(cc => {
-                if (getEnemyDistance(message.target.token, cc.token) <= 15 && getEnemyDistance(message.token, cc.token) <= 15) {
+                if (getEnemyDistance(message.target?.token, cc.token) <= 15 && getEnemyDistance(message.token, cc.token) <= 15) {
                     const retributivestrike = actorAction(cc.actor, "retributive-strike");
                     if (retributivestrike) {
                         postTargetInChatTemplate(_uuid(retributivestrike), cc);
@@ -126,9 +126,9 @@ async function denierOfDestruction(message) {
         //ally damaged
         if (message?.target) {
             (isTargetCharacter(message) ? characterWithReaction() : npcWithReaction())
-            .filter(a=>a?.actor?.id != message?.target?.actor._id)
+            .filter(a=>a?.actor?.id !== message?.target?.actor._id)
             .forEach(cc => {
-                if (getEnemyDistance(message.target.token, cc.token) <= 30) {
+                if (getEnemyDistance(message.target?.token, cc.token) <= 30) {
                     const dod = actorAction(cc.actor, "denier-of-destruction");
                     if (dod) {
                         postTargetInChatTemplate(_uuid(dod), cc);
@@ -144,9 +144,9 @@ async function glimpseOfRedemption(message) {
         //ally damaged
         if (message?.target) {
             (isTargetCharacter(message) ? characterWithReaction() : npcWithReaction())
-            .filter(a=>a?.actor?.id != message?.target?.actor._id)
+            .filter(a=>a?.actor?.id !== message?.target?.actor._id)
             .forEach(cc => {
-                if (getEnemyDistance(message.target.token, cc.token) <= 15 && getEnemyDistance(message.token, cc.token) <= 15) {
+                if (getEnemyDistance(message.target?.token, cc.token) <= 15 && getEnemyDistance(message.token, cc.token) <= 15) {
                     const gor = actorAction(cc.actor, "glimpse-of-redemption");
                     if (gor) {
                         postTargetInChatTemplate(_uuid(gor), cc);
@@ -162,9 +162,9 @@ async function liberatingStep(message) {
         //ally damaged
         if (message?.target) {
             (isTargetCharacter(message) ? characterWithReaction() : npcWithReaction())
-            .filter(a=>a?.actor?.id != message?.target?.actor._id)
+            .filter(a=>a?.actor?.id !== message?.target?.actor._id)
             .forEach(cc => {
-                if (getEnemyDistance(message.target.token, cc.token) <= 15 && getEnemyDistance(message.token, cc.token) <= 15) {
+                if (getEnemyDistance(message.target?.token, cc.token) <= 15 && getEnemyDistance(message.token, cc.token) <= 15) {
                     const liberatingstep = actorAction(cc.actor, "liberating-step");
                     if (liberatingstep) {
                         postTargetInChatTemplate(_uuid(liberatingstep), cc);
@@ -175,10 +175,10 @@ async function liberatingStep(message) {
     } else if (messageType(message, 'skill-check')) {
         if (isTargetCharacter(message) && anySuccessMessageOutcome(message)) {
             characterWithReaction()
-            .filter(a=>a?.actor?.id != message?.target?.actor._id)
+            .filter(a=>a?.actor?.id !== message?.target?.actor._id)
             .forEach(cc => {
                 if (message?.flags?.pf2e?.context?.options.find(bb=>bb==="action:grapple")) {
-                    if (getEnemyDistance(message.target.token, cc.token) <= 15 && getEnemyDistance(message.token, cc.token) <= 15){
+                    if (getEnemyDistance(message.target?.token, cc.token) <= 15 && getEnemyDistance(message.token, cc.token) <= 15){
                         const liberating_step = actorAction(cc.actor, "liberating-step");
                         if (liberating_step) {
                             postTargetInChatTemplate(_uuid(liberating_step), cc);
@@ -205,10 +205,10 @@ async function vengefulSpite(message) {
 
 async function reactiveGnaw(message) {
     if (messageType(message, 'damage-roll')) {
-        if (hasReaction(message?.target?.token?.combatant) && adjacentEnemy(message.target.token, message.token)) {
+        if (hasReaction(message?.target?.token?.combatant) && adjacentEnemy(message.target?.token, message.token)) {
             const rg = actorAction(message?.target?.actor, "reactive-gnaw");
             if (rg && message?.item?.system?.damage?.damageType === "slashing") {
-                await postInChatTemplate(_uuid(rg), message.target.token.combatant);
+                await postInChatTemplate(_uuid(rg), message.target?.token.combatant);
             }
         }
     }
@@ -216,10 +216,10 @@ async function reactiveGnaw(message) {
 
 async function ironCommand(message) {
     if (messageType(message, 'damage-roll')) {
-        if (hasReaction(message?.target?.token?.combatant) && getEnemyDistance(message?.target.token, message.token) <= 15) {
+        if (hasReaction(message?.target?.token?.combatant) && getEnemyDistance(message?.target?.token, message.token) <= 15) {
             const iron_command = actorAction(message?.target?.actor, "iron-command");
             if (iron_command) {
-                await postInChatTemplate(_uuid(iron_command), message.target.token.combatant);
+                await postInChatTemplate(_uuid(iron_command), message.target?.token.combatant);
             }
         }
     }
@@ -227,10 +227,10 @@ async function ironCommand(message) {
 
 async function selfishShield(message) {
     if (messageType(message, 'damage-roll')) {
-        if (hasReaction(message?.target?.token?.combatant) && getEnemyDistance(message?.target.token, message.token) <= 15) {
+        if (hasReaction(message?.target?.token?.combatant) && getEnemyDistance(message?.target?.token, message.token) <= 15) {
             const selfish_shield = actorAction(message?.target?.actor, "selfish-shield");
             if (selfish_shield) {
-                await postInChatTemplate(_uuid(selfish_shield), message.target.token.combatant);
+                await postInChatTemplate(_uuid(selfish_shield), message.target?.token.combatant);
             }
         }
     }
@@ -238,10 +238,10 @@ async function selfishShield(message) {
 
 async function destructiveVengeance(message) {
     if (messageType(message, 'damage-roll')) {
-        if (hasReaction(message?.target?.token?.combatant) && getEnemyDistance(message?.target.token, message.token) <= 15) {
+        if (hasReaction(message?.target?.token?.combatant) && getEnemyDistance(message?.target?.token, message.token) <= 15) {
             const destructive_vengeance = actorAction(message?.target?.actor, "destructive-vengeance");
             if (destructive_vengeance) {
-                await postInChatTemplate(_uuid(destructive_vengeance), message.target.token.combatant);
+                await postInChatTemplate(_uuid(destructive_vengeance), message.target?.token.combatant);
             }
         }
     }
@@ -305,7 +305,7 @@ async function wickedThorns(message) {
                 const wicked_thorns = actorAction(message?.target?.actor, "wicked-thorns");
                 if (wicked_thorns) {
                     if (message?.item?.traits.has("unarmed") || (message?.item?.isMelee && nonReach(message?.item?.traits))) {
-                        await postInChatTemplate(_uuid(wicked_thorns), message.target.token.combatant);
+                        await postInChatTemplate(_uuid(wicked_thorns), message.target?.token.combatant);
                     }
                 }
             }

--- a/src/feats.js
+++ b/src/feats.js
@@ -1,5 +1,5 @@
 async function bansheeCry(message) {
-    if (message?.item?.type != 'spell') {return}
+    if (message?.item?.type !== 'spell') {return}
     if (!message.item.components.verbal) {return}
 
     (isActorCharacter(message.actor) ? npcWithReaction() : characterWithReaction())
@@ -22,7 +22,7 @@ async function opportuneBackstab(message) {
         .filter(a=>a.actorId !== message?.actor?._id)
         .forEach(cc => {
             const opportune_backstab = actorFeat(cc.actor, "opportune-backstab");
-            if (opportune_backstab && canReachEnemy(message.target.token, cc.token, cc.actor)) {
+            if (opportune_backstab && canReachEnemy(message.target?.token, cc.token, cc.actor)) {
                 postInChatTemplate(_uuid(opportune_backstab), cc);
             }
         })
@@ -117,11 +117,11 @@ async function cleave(message) {
         if (hasReaction(message?.actor?.combatant)) {
             const cleave = actorFeat(message.actor, "cleave");
             if (cleave && message?.item?.isMelee) {
-                if (message.target.actor.system.attributes.hp.value <= parseInt(message.content)) {
+                if (message.target?.actor.system.attributes.hp.value <= parseInt(message.content)) {
 
                     const adjEnemies = game.combat?.turns?.filter(a => !isActorCharacter(a.actor))
                         .filter(a => a.actorId !== message?.target?.actor._id)
-                        .filter(a => adjacentEnemy(message.target.token, a.token))
+                        .filter(a => adjacentEnemy(message.target?.token, a.token))
                         .filter(a => a.actor.system.attributes.hp.value > 0);
 
                     if (adjEnemies.length > 0) {
@@ -139,8 +139,8 @@ async function shieldBlock(message) {
             const dTypes = Object.values(message?.item?.system?.damageRolls ?? {a: message?.item?.system?.damage}).map(a=>a?.damageType);
             if (dTypes.filter(a=> a=== "bludgeoning" || a === "piercing" || a=== "slashing").length > 0) {
                 const sblock = actorFeat(message?.target?.actor, "shield-block");
-                if (sblock && hasEffect(message.target.actor, "effect-raise-a-shield")) {
-                    await postInChatTemplate(_uuid(sblock), message.target.token.combatant, "shield-block");
+                if (sblock && hasEffect(message.target?.actor, "effect-raise-a-shield")) {
+                    await postInChatTemplate(_uuid(sblock), message.target?.token.combatant, "shield-block");
                 }
             }
         }
@@ -163,7 +163,7 @@ async function allInMyHead(message) {
         if (hasReaction(message?.target?.token?.combatant)) {
             const all_in = actorFeat(message?.target?.actor, "all-in-my-head");
             if (all_in && !message?.item?.traits.has("death")) {
-                await postInChatTemplate(_uuid(all_in), message.target.token.combatant);
+                await postInChatTemplate(_uuid(all_in), message.target?.token.combatant);
             }
         }
     }
@@ -174,7 +174,7 @@ async function unexpectedShift(message) {
         if (hasReaction(message?.target?.token?.combatant)) {
             const unexpecteds = actorFeat(message?.target?.actor, "unexpected-shift");
             if (unexpecteds) {
-                await postInChatTemplate(_uuid(unexpecteds), message.target.token.combatant);
+                await postInChatTemplate(_uuid(unexpecteds), message.target?.token.combatant);
             }
         }
     }
@@ -187,7 +187,7 @@ async function resoundingFinale(message) {
             if (dTypes.filter(a=> a=== "sonic").length > 0) {
                 const resounding = actorFeat(message?.target?.actor, "resounding-finale");
                 if (resounding) {
-                    await postInChatTemplate(_uuid(resounding), message.target.token.combatant);
+                    await postInChatTemplate(_uuid(resounding), message.target?.token.combatant);
                 }
             }
         }
@@ -201,7 +201,7 @@ async function reverberate(message) {
             if (dTypes.filter(a=> a=== "sonic").length > 0) {
                 const reverberate = actorFeat(message?.target?.actor, "reverberate");
                 if (reverberate && message.item.type === "spell") {
-                    await postInChatTemplate(_uuid(reverberate), message.target.token.combatant);
+                    await postInChatTemplate(_uuid(reverberate), message.target?.token.combatant);
                 }
             }
         }
@@ -213,7 +213,7 @@ async function verdantPresence(message) {
         if (hasReaction(message?.target?.token?.combatant)) {
             const verdantp = actorFeat(message?.target?.actor, "verdant-presence");
             if (verdantp) {
-                await postInChatTemplate(_uuid(verdantp), message.target.token.combatant);
+                await postInChatTemplate(_uuid(verdantp), message.target?.token.combatant);
             }
         }
     }
@@ -305,7 +305,7 @@ async function youFailedToAccountForThis(message) {
         if (hasReaction(message?.target?.token?.combatant)) {
             const you_failed_to = actorFeat(message?.target?.actor, "you-failed-to-account-for-this");
             if (you_failed_to) {
-                await postInChatTemplate(_uuid(you_failed_to), message.target.token.combatant);
+                await postInChatTemplate(_uuid(you_failed_to), message.target?.token.combatant);
             }
         }
     }
@@ -316,7 +316,7 @@ async function suspectOfOpportunity(message) {
         if (hasReaction(message?.target?.token?.combatant)) {
             const suspect_of_opportunity = actorFeat(message?.target?.actor, "suspect-of-opportunity");
             if (suspect_of_opportunity) {
-                await postInChatTemplate(_uuid(suspect_of_opportunity), message.target.token.combatant);
+                await postInChatTemplate(_uuid(suspect_of_opportunity), message.target?.token.combatant);
             }
         }
     }
@@ -327,7 +327,7 @@ async function foreseeDanger(message) {
         if (hasReaction(message?.target?.token?.combatant)) {
             const foresee_danger = actorFeat(message?.target?.actor, "foresee-danger");
             if (foresee_danger) {
-                await postInChatTemplate(_uuid(foresee_danger), message.target.token.combatant);
+                await postInChatTemplate(_uuid(foresee_danger), message.target?.token.combatant);
             }
         }
     }
@@ -378,7 +378,7 @@ async function sacrificeArmor(message) {
             if (dTypes.filter(a=> a=== "bludgeoning" || a === "piercing" || a=== "slashing").length > 0) {
                 const sarmor = actorFeat(message?.target?.actor, "sacrifice-armor");
                 if (sarmor) {
-                    await postInChatTemplate(_uuid(sarmor), message.target.token.combatant);
+                    await postInChatTemplate(_uuid(sarmor), message.target?.token.combatant);
                 }
             }
         }
@@ -393,7 +393,7 @@ async function reactiveTransformation(message) {
             if (dTypes.filter(a=> ["acid", "cold", "electricity", "fire", 'poison'].includes(a)).length > 0) {
                 const reactivet = actorFeat(message?.target?.actor, "reactive-transformation");
                 if (reactivet) {
-                    await postInChatTemplate(_uuid(reactivet), message.target.token.combatant);
+                    await postInChatTemplate(_uuid(reactivet), message.target?.token.combatant);
                 }
             }
         }
@@ -412,7 +412,7 @@ async function fakeOut(message) {
                     const weapon = hasLoadedFirearmOrCrossbow(cc.actor);
                     if (weapon.length > 0) {
                         const range = Math.max(...weapon.map(a => a.item.rangeIncrement));
-                        if (getEnemyDistance(cc?.token, message.target.token) <= range) {
+                        if (getEnemyDistance(cc?.token, message.target?.token) <= range) {
                             postInChatTemplate(_uuid(fake_out), cc);
                         }
                     }
@@ -472,7 +472,7 @@ async function no(message) {
 
 async function woundedRage(message) {
     if (message?.flags?.pf2e?.appliedDamage && !message?.flags?.pf2e?.appliedDamage?.isHealing) {
-        if (message.actor.system?.attributes?.hp?.value != 0 && hasReaction(message?.token?.combatant)) {
+        if (message.actor.system?.attributes?.hp?.value !== 0 && hasReaction(message?.token?.combatant)) {
             const wounded_rage = actorFeat(message?.actor, "wounded-rage");
             if (wounded_rage && !hasCondition(message?.actor,"encumbered") && !hasEffect(message.actor, "effect-rage")) {
                 await postInChatTemplate(_uuid(wounded_rage), message?.token?.combatant);
@@ -483,7 +483,7 @@ async function woundedRage(message) {
 
 async function negateDamage(message) {
     if (message?.flags?.pf2e?.appliedDamage && !message?.flags?.pf2e?.appliedDamage?.isHealing) {
-        if (message.actor.system?.attributes?.hp?.value != 0 && hasReaction(message?.token?.combatant)) {
+        if (message.actor.system?.attributes?.hp?.value !== 0 && hasReaction(message?.token?.combatant)) {
             const negate_damage = actorFeat(message?.actor, "negate-damage");
             if (negate_damage) {
                 await postInChatTemplate(_uuid(negate_damage), message?.token?.combatant);
@@ -510,7 +510,7 @@ async function embraceThePain(message) {
         if (hasReaction(message?.target?.token?.combatant)) {
             const embracethepain = actorFeat(message?.target?.actor, "embrace-the-pain");
             if (message?.item?.isMelee && embracethepain) {
-                await postInChatTemplate(_uuid(embracethepain), message.target.token.combatant);
+                await postInChatTemplate(_uuid(embracethepain), message.target?.token.combatant);
             }
         }
     }
@@ -518,11 +518,11 @@ async function embraceThePain(message) {
 
 async function retaliatoryCleansing(message) {
     if (messageType(message, 'damage-roll')) {
-        if (hasReaction(message?.target?.token?.combatant) && adjacentEnemy(message.target.token, message.token)) {
+        if (hasReaction(message?.target?.token?.combatant) && adjacentEnemy(message.target?.token, message.token)) {
             const rc = actorFeat(message?.target?.actor, "retaliatory-cleansing");
             if (rc) {
                 if (actorHeldWeapon(message?.target?.actor).filter(a=>a.slug==="holy-water" || (a.weaponTraits.filter(b=>b.name === "bomb").length > 0 && a.weaponTraits.filter(b=>b.name === "positive").length > 0)).length > 0) {
-                    await postInChatTemplate(_uuid(rc), message.target.token.combatant);
+                    await postInChatTemplate(_uuid(rc), message.target?.token.combatant);
                 }
             }
         }
@@ -534,7 +534,7 @@ async function nimbleDodge(message) {
         if (hasReaction(message?.target?.token?.combatant)) {
             const nimble_dodge = actorFeat(message?.target?.actor, "nimble-dodge") ?? actorAction(message?.target?.actor, "nimble-dodge");
             if (nimble_dodge && !hasCondition(message?.target?.actor,"encumbered")) {
-                await postInChatTemplate(_uuid(nimble_dodge), message.target.token.combatant);
+                await postInChatTemplate(_uuid(nimble_dodge), message.target?.token.combatant);
             }
         }
     }
@@ -545,7 +545,7 @@ async function airyStep(message) {
         if (hasReaction(message?.target?.token?.combatant)) {
             const airy_step = actorFeat(message?.target?.actor, "airy-step") ?? actorAction(message?.target?.actor, "airy-step");
             if (airy_step) {
-                await postInChatTemplate(_uuid(nimble_dodge), message.target.token.combatant);
+                await postInChatTemplate(_uuid(nimble_dodge), message.target?.token.combatant);
             }
         }
     }
@@ -556,7 +556,7 @@ async function farabellusFlip(message) {
         if (hasReaction(message?.target?.token?.combatant)) {
             const farabellus_flip = actorFeat(message?.target?.actor, "farabellus-flip");
             if (farabellus_flip) {
-                await postInChatTemplate(_uuid(farabellus_flip), message.target.token.combatant);
+                await postInChatTemplate(_uuid(farabellus_flip), message.target?.token.combatant);
             }
         }
     }
@@ -567,7 +567,7 @@ async function reactiveShield(message) {
         if (hasReaction(message?.target?.token?.combatant)) {
             const reactive_shield = actorFeat(message?.target?.actor, "reactive-shield");
             if (reactive_shield && !hasEffect(message?.target?.actor, "effect-raise-a-shield") && message?.item?.isMelee) {
-                await postInChatTemplate(_uuid(reactive_shield), message.target.token.combatant);
+                await postInChatTemplate(_uuid(reactive_shield), message.target?.token.combatant);
             }
         }
     }
@@ -578,7 +578,7 @@ async function pirouette(message) {
         if (hasReaction(message?.target?.token?.combatant)) {
             const pirouette = actorFeat(message?.target?.actor, "pirouette");
             if (pirouette && hasEffect(message?.target?.actor, "stance-masquerade-of-seasons-stance")) {
-                await postInChatTemplate(_uuid(pirouette), message.target.token.combatant);
+                await postInChatTemplate(_uuid(pirouette), message.target?.token.combatant);
             }
         }
     }
@@ -588,9 +588,9 @@ async function fieryRetort(message) {
     if (messageType(message, 'attack-roll') && anySuccessMessageOutcome(message)) {
         if (hasReaction(message?.target?.token?.combatant)) {
             const fiery_retort = actorFeat(message?.target?.actor, "fiery-retort");
-            if (fiery_retort && adjacentEnemy(message.token, message.target.token)
+            if (fiery_retort && adjacentEnemy(message.token, message.target?.token)
                 && (message?.item?.isMelee|| message?.item?.traits?.has("unarmed"))) {
-                await postInChatTemplate(_uuid(fiery_retort), message.target.token.combatant);
+                await postInChatTemplate(_uuid(fiery_retort), message.target?.token.combatant);
             }
         }
     }
@@ -604,7 +604,7 @@ async function knightsRetaliation(message) {
                 && message?.actor?.system.traits.value.includes("undead")
                 && criticalFailureMessageOutcome(message)
             ) {
-                await postInChatTemplate(_uuid(knights_retaliation), message.target.token.combatant);
+                await postInChatTemplate(_uuid(knights_retaliation), message.target?.token.combatant);
             }
         }
     }
@@ -614,7 +614,7 @@ async function tangleOfBattle(message) {
     if (messageType(message, 'attack-roll') && criticalSuccessMessageOutcome(message)) {
         if (hasReaction(message?.token?.combatant)) {
             const tob = actorFeat(message?.actor, "tangle-of-battle");
-            if (tob && adjacentEnemy(message.target.token, message?.token)) {
+            if (tob && adjacentEnemy(message.target?.token, message?.token)) {
                 await postInChatTemplate(_uuid(tob), message.token.combatant);
             }
         }
@@ -637,7 +637,7 @@ async function opportuneRiposte(message) {
         if (criticalFailureMessageOutcome(message) && hasReaction(message?.target?.token?.combatant, "opportune-riposte")) {
             const opportune_riposte = actorFeat(message?.target?.actor, "opportune-riposte") ?? actorAction(message?.target?.actor, "opportune-riposte");
             if (canReachEnemy(message.token, message?.target?.token, message?.target?.actor) && opportune_riposte) {
-                await postInChatTemplate(_uuid(opportune_riposte), message.target.token.combatant, "opportune-riposte");
+                await postInChatTemplate(_uuid(opportune_riposte), message.target?.token.combatant, "opportune-riposte");
             }
         }
     }
@@ -647,8 +647,8 @@ async function duelingRiposte(message) {
     if (messageType(message, 'attack-roll')) {
         if (criticalFailureMessageOutcome(message) && hasReaction(message?.target?.token?.combatant)) {
             const dueling_riposte = actorFeat(message?.target?.actor, "dueling-riposte");
-            if (dueling_riposte && hasEffect(message.target.actor, "effect-dueling-parry")) {
-                await postInChatTemplate(_uuid(dueling_riposte), message.target.token.combatant);
+            if (dueling_riposte && hasEffect(message.target?.actor, "effect-dueling-parry")) {
+                await postInChatTemplate(_uuid(dueling_riposte), message.target?.token.combatant);
             }
         }
     }
@@ -659,8 +659,8 @@ async function twinRiposte(message) {
         if (criticalFailureMessageOutcome(message) && hasReaction(message?.target?.token?.combatant)) {
             const twin_riposte = actorFeat(message?.target?.actor, "twin-riposte");
             if (twin_riposte && canReachEnemy(message.token, message?.target?.token, message?.target?.actor)
-                && (hasEffect(message.target.actor, "effect-twin-parry")||hasEffect(message.target.actor, "effect-twin-parry-parry-trait"))) {
-                await postInChatTemplate(_uuid(twin_riposte), message.target.token.combatant);
+                && (hasEffect(message.target?.actor, "effect-twin-parry")||hasEffect(message.target?.actor, "effect-twin-parry-parry-trait"))) {
+                await postInChatTemplate(_uuid(twin_riposte), message.target?.token.combatant);
             }
         }
     }
@@ -685,7 +685,7 @@ async function furiousVengeance(message) {
             if (hasReaction(message?.target?.token?.combatant)) {
                 const fv = actorFeat(message?.target?.actor, "furious-vengeance")
                 if (canReachEnemy(message.token, message?.target?.token, message?.target?.actor) && fv) {
-                    await postInChatTemplate(_uuid(fv), message.target.token.combatant);
+                    await postInChatTemplate(_uuid(fv), message.target?.token.combatant);
                 }
             }
         }
@@ -698,7 +698,7 @@ async function cringe(message) {
             if (hasReaction(message?.target?.token?.combatant)) {
                 const cringe = actorFeat(message?.target?.actor, "cringe");
                 if (cringe) {
-                    await postInChatTemplate(_uuid(cringe), message.target.token.combatant);
+                    await postInChatTemplate(_uuid(cringe), message.target?.token.combatant);
                 }
             }
         }
@@ -713,7 +713,7 @@ async function stormRetribution(message) {
                     if (message?.target?.actor?.system?.resources?.focus?.value > 0) {
                         const sr = actorFeat(message?.target?.actor, "storm-retribution")
                         if (sr) {
-                            await postInChatTemplate(_uuid(sr), message.target.token.combatant);
+                            await postInChatTemplate(_uuid(sr), message.target?.token.combatant);
                         }
                     }
                 }
@@ -801,7 +801,7 @@ async function emergencyTarge(message) {
         if (hasReaction(message?.target?.token?.combatant)) {
             const emergency_targe = actorFeat(message?.target?.actor, "emergency-targe");
             if (emergency_targe && message?.item?.isMelee) {
-                await postInChatTemplate(_uuid(emergency_targe), message.target.token.combatant);
+                await postInChatTemplate(_uuid(emergency_targe), message.target?.token.combatant);
             }
         }
     }
@@ -815,7 +815,7 @@ async function impossibleTechnique(message) {
                 && !hasCondition(message?.target?.actor, "fatigued")
                 && message?.target?.actor?.armorClass?.parent?.item?.type !== "armor"
             ) {
-                await postInChatTemplate(_uuid(impossible_technique), message.target.token.combatant);
+                await postInChatTemplate(_uuid(impossible_technique), message.target?.token.combatant);
             }
         }
     }
@@ -829,7 +829,7 @@ async function ripplingSpin(message) {
                 && canReachEnemy(message.token, message?.target?.token, message?.target?.actor)
                 && hasEffect(message?.target?.actor, "stance-reflective-ripple-stance")
             ) {
-                await postInChatTemplate(_uuid(rippling_spin), message.target.token.combatant);
+                await postInChatTemplate(_uuid(rippling_spin), message.target?.token.combatant);
             }
         }
     }
@@ -843,7 +843,7 @@ async function guardiansDeflectionFighter(message) {
 
             if (rr.degreeOfSuccess !== newR) {
                 characterWithReaction()
-                    .filter(a=>a?.actor?.id != message?.target?.actor._id)
+                    .filter(a=>a?.actor?.id !== message?.target?.actor._id)
                     .filter(cc=>canReachEnemy(message?.target?.token, cc.token, cc.actor))
                     .forEach(cc => {
                         const guardians_def = actorFeat(cc.actor, "guardians-deflection-fighter");
@@ -864,7 +864,7 @@ async function guardiansDeflectionSwashbuckler(message) {
 
             if (rr.degreeOfSuccess !== newR) {
                 characterWithReaction()
-                    .filter(a=>a?.actor?.id != message?.target?.actor._id)
+                    .filter(a=>a?.actor?.id !== message?.target?.actor._id)
                     .filter(cc=>canReachEnemy(message?.target?.token, cc.token, cc.actor))
                     .forEach(cc => {
                         const guardians_def = actorFeat(cc.actor, "guardians-deflection-swashbuckler");
@@ -886,7 +886,7 @@ async function shieldWardenFighter(message) {
     characterWithReaction()
         .filter(a=>a.actorId !== message?.actor?._id)
         .filter(a=>hasEffect(a.actor, "effect-raise-a-shield"))
-        .filter(a=>adjacentEnemy(message.target.token, a.token))
+        .filter(a=>adjacentEnemy(message.target?.token, a.token))
         .forEach(cc => {
             const shield_warden = actorFeat(cc.actor, "shield-warden-fighter");
             if (shield_warden) {
@@ -904,7 +904,7 @@ async function shieldWardenChampion(message) {
     characterWithReaction()
         .filter(a=>a.actorId !== message?.actor?._id)
         .filter(a=>hasEffect(a.actor, "effect-raise-a-shield"))
-        .filter(a=>adjacentEnemy(message.target.token, a.token))
+        .filter(a=>adjacentEnemy(message.target?.token, a.token))
         .forEach(cc => {
             const shield_warden = actorFeat(cc.actor, "shield-warden-champion");
             if (shield_warden) {

--- a/src/homebrew.js
+++ b/src/homebrew.js
@@ -452,7 +452,7 @@ function combatantsForTriggers(tt, message) {
         }
         if (tr.name === 'AllyTakeDamage' && messageType(message, 'damage-roll')) {
             const t = filterByDistance((isTargetCharacter(message) ? characterWithReaction() : npcWithReaction())
-            .filter(a=>a?.actor?.id != message?.target?.actor._id), tr, message);
+            .filter(a=>a?.actor?.id !== message?.target?.actor._id), tr, message);
             res = res.concat(t);
         }
         if (tr.name === 'ActorTakeDamage' && messageType(message, 'damage-roll')) {
@@ -508,7 +508,7 @@ function combatantsForTriggers(tt, message) {
         }
         if (tr.name === 'CreatureAttacksAlly' && messageType(message, 'attack-roll')) {
             const t = filterByDistance((isActorCharacter(message?.actor) ? npcWithReaction() : characterWithReaction())
-                .filter(a=>a?.actor?.id != message?.target?.actor._id), tr, message);
+                .filter(a=>a?.actor?.id !== message?.target?.actor._id), tr, message);
             res = res.concat(t);
         }
         if (tr.name === 'ActorFailsSkillCheck' && messageType(message, 'skill-check') && anyFailureMessageOutcome(message)) {

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -601,8 +601,8 @@ Hooks.on('preCreateChatMessage',async (message, user, _options, userId)=>{
             .map(a=>a?.damageType).find(a=> a === "slashing")
         ) {
             const ImNotCrying = actorActionBySource(message?.target?.actor, "Item.ncKVztM6EL4i98dL");
-            if (ImNotCrying && adjacentEnemy(message.target.token, message.token)) {
-                await postInChatTemplate(_uuid(ImNotCrying), message.target.token.combatant);
+            if (ImNotCrying && adjacentEnemy(message.target?.token, message.token)) {
+                await postInChatTemplate(_uuid(ImNotCrying), message.target?.token.combatant);
             }
         }
     }

--- a/src/used.js
+++ b/src/used.js
@@ -32,18 +32,18 @@ Hooks.on('preCreateChatMessage', async (message, user, _options, userId)=>{
     if (messageType(message, 'attack-roll')) {
 
         if (hasOption(message, "hit-the-dirt") && hasOption(message, "item:ranged")) {
-            decreaseReaction(message.target.token.combatant);
-            reactionWasUsedChat(hit_the_dirt, message.target.token.combatant);
+            decreaseReaction(message.target?.token.combatant);
+            reactionWasUsedChat(hit_the_dirt, message.target?.token.combatant);
         }
 
         if (message?.item?.isMelee && message?.target?.actor?.flags?.pf2e?.rollOptions?.all?.['crane-flutter']) {
-            decreaseReaction(message.target.token.combatant);
-            reactionWasUsedChat(crane_flutter, message.target.token.combatant);
+            decreaseReaction(message.target?.token.combatant);
+            reactionWasUsedChat(crane_flutter, message.target?.token.combatant);
         }
 
         if (message?.item?.isRanged && message?.target?.actor?.flags?.pf2e?.rollOptions?.ac?.['deflect-arrow']) {
-            decreaseReaction(message.target.token.combatant);
-            reactionWasUsedChat(deflect_arrow, message.target.token.combatant);
+            decreaseReaction(message.target?.token.combatant);
+            reactionWasUsedChat(deflect_arrow, message.target?.token.combatant);
         }
 
     } else if (messageType(message, "saving-throw")) {


### PR DESCRIPTION
…inst target being undefined. This is the simple search/replace of all .target. to .target?. and != to !== I did while playing. It can definitely be cut down as I can see you normally guard against it.